### PR TITLE
fix: fix switching of fetching after error

### DIFF
--- a/src/tokenRefreshLink.ts
+++ b/src/tokenRefreshLink.ts
@@ -153,7 +153,11 @@ export class TokenRefreshLink extends ApolloLink {
           this.fetching = false;
           this.queue.consumeQueue();
         })
-        .catch(this.handleError);
+        .catch(err => {
+          this.fetching = false;
+          this.handleError(err);
+        }
+        );
     }
 
     return this.queue.enqueueRequest({


### PR DESCRIPTION
Faced with such a problem that after an error during a request for an access token (for example, a refresh token is expired), the "fetching" property does not become a falsa, but it remains true.