### PR TITLE
experimental: support apollo v3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "author": "Denis Akiyakov <newsiberian2015@yandex.ru>",
   "license": "MIT",
   "dependencies": {
+    "@apollo/client": "^3.0.0-beta.41",
     "apollo-link": "^1.2.3"
   },
   "peerDependencies": {

--- a/src/queuing.ts
+++ b/src/queuing.ts
@@ -1,4 +1,5 @@
-import { Observable, Operation, NextLink, FetchResult } from 'apollo-link';
+import { Observable, Operation, NextLink, FetchResult } from '@apollo/client';
+import { print } from 'graphql/language/printer';
 
 export interface SubscriberInterface {
   next?: (result: FetchResult) => void;
@@ -52,7 +53,7 @@ export class OperationQueuing {
 
   public consumeQueue(): void {
     this.queuedRequests.forEach(request => {
-      const key = request.operation.toKey();
+      const key = requestToKey(request)
       this.subscriptions[key] =
         request.forward(request.operation).subscribe(request.subscriber);
 
@@ -63,4 +64,14 @@ export class OperationQueuing {
 
     this.queuedRequests = [];
   }
+}
+
+function requestToKey(request: QueuedRequest): string {
+  const queryString =
+    typeof request.operation.query === 'string' ? request.operation.query : print(request.operation.query);
+
+  return JSON.stringify({
+    variables: request.operation.variables || {},
+    query: queryString,
+  });
 }

--- a/src/tokenRefreshLink.ts
+++ b/src/tokenRefreshLink.ts
@@ -4,7 +4,7 @@ import {
   Operation,
   NextLink,
   FetchResult,
-} from 'apollo-link';
+} from '@apollo/client';
 
 import { OperationQueuing } from './queuing';
 


### PR DESCRIPTION
NOTE: This PR is intended to start discussion about supporting Apollo 3.0. It's not intended to be a finished product.

**exports**
I learned that the Apollo team has merged `apollo-link` into `@apollo/client` and changed [exports], so that part is updated.

**operation.toKey()**
Because `apollo-link-token-refresh` [relies] on Apollo's `operation.toKey()` for the request queue, and because Apollo 3 drops this ([version 2], [version 3]) a workaround is needed.


[exports]: http://youtu.be/n_j8QckQN5I?t=365
[relies]: https://github.com/newsiberian/apollo-link-token-refresh/blob/4abf545e2a70e59235f545776d155310fecfa1e9/src/queuing.ts#L55
[version 2]: https://github.com/apollographql/apollo-
[version 2]: https://github.com/apollographql/apollo-link/blob/9a07942b3b8b908c9cdc6863e746ac87284c735b/packages/apollo-link/src/types.ts#L21
[version 3]: https://github.com/apollographql/apollo-client/blob/c14c94b73ada83c92d75271d3a5dc17b03ccb85f/src/link/core/types.ts#L15